### PR TITLE
Added ID to all service responses

### DIFF
--- a/srv/GetObjectIp.srv
+++ b/srv/GetObjectIp.srv
@@ -1,4 +1,5 @@
 uint32 id
 ---
 bool success true
+uint32 id
 string ip

--- a/srv/GetObjectTrajectory.srv
+++ b/srv/GetObjectTrajectory.srv
@@ -1,4 +1,5 @@
 uint32 id
 ---
 bool success true
+uint32 id
 CartesianTrajectory trajectory

--- a/srv/GetObjectTriggerStart.srv
+++ b/srv/GetObjectTriggerStart.srv
@@ -1,4 +1,5 @@
 uint32 id
 ---
 bool success true
+uint32 id
 bool trigger_start


### PR DESCRIPTION
Since the response is always handled by a callback, it is good to know what ID the request contained when handling.