### PR TITLE
Feature state change message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/CartesianTrajectoryPoint.msg"
   "msg/CartesianTolerance.msg"
   "msg/ObjectTriggerStart.msg"
+  "msg/StateChange.msg"
   "srv/GetObjectIds.srv"
   "srv/GetTestOrigin.srv"
   "srv/GetObjectTriggerStart.srv"

--- a/msg/StateChange.msg
+++ b/msg/StateChange.msg
@@ -1,0 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+uint8 prev_state
+uint8 state

--- a/msg/StateChange.msg
+++ b/msg/StateChange.msg
@@ -3,4 +3,4 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 uint8 prev_state
-uint8 state
+uint8 current_state

--- a/msg/StateChange.msg
+++ b/msg/StateChange.msg
@@ -2,5 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+uint8 STATE_UNKNOWN=0
+uint8 STATE_INIT=1
+uint8 STATE_DISARMED=2
+uint8 STATE_ARMED=3
+uint8 STATE_RUNNING=4
+uint8 STATE_POSTRUN=5
+uint8 STATE_ABORTING=6
+uint8 STATE_REMOTE_CONTROL=7
+uint8 STATE_PRE_ARMING=8
+uint8 STATE_PRE_RUNNING=9
 uint8 prev_state
 uint8 current_state


### PR DESCRIPTION
Added a state change message, the message contains the previous state and the current state. The idea is that this message is published when going from one state to another, in order to keep track of if the change state is legal or not.