### PR TITLE
Added a service message for setting object IPs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/GetObjectIp.srv"
   "srv/GetObjectControlState.srv"
   "srv/GetObjectReturnTrajectory.srv"
+  "srv/SetObjectIp.srv"
   DEPENDENCIES builtin_interfaces geometry_msgs geographic_msgs std_msgs
 )
 

--- a/srv/SetObjectIp.srv
+++ b/srv/SetObjectIp.srv
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+string SERVICE_NAME = "set_object_ip"
+
+uint32 id
+string ip
+---
+bool success true
+uint32 id
+string ip


### PR DESCRIPTION
Added a service to Esmini adapter to change the IP address of an object. Let me know what you think about adding the service name in the service message (accessible through SetObjectIp::Request::SERVICE_NAME) instead of in the [module.hpp](https://github.com/RI-SE/ATOS/blob/b9b06f936d419467ea3a0fcab88ec7b382a321ab/common/module.hpp#L14).

Related to [PR #626](https://github.com/RI-SE/ATOS/pull/626) in ATOS